### PR TITLE
Fix ServerIP env for Pi-hole in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     environment:
       TZ: "America/Los_Angeles"
       WEBPASSWORD: "" # Blank password - Can be whatever you want.
-      ServerIP: 10.1.0.100 # Internal IP of pihole
+      ServerIP: 10.2.0.100 # Internal IP of pihole
       DNS1: 10.2.0.200 # Unbound IP
       DNS2: 10.2.0.200 # If we don't specify two, it will auto pick google.
     # Volumes store your data between container upgrades


### PR DESCRIPTION
Which leads to Pi-hole incorrectly resolve `pi.hole` to `10.1.0.100` which doesn't exist