### PR TITLE
fix unbound's verbosity level & a typo

### DIFF
--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -60,7 +60,7 @@ server:
     logfile: /dev/null
 
     # Only log errors
-    verbosity: 1
+    verbosity: 0
 
     ###########################################################################
     # PRIVACY SETTINGS
@@ -301,7 +301,7 @@ server:
     # include: /opt/unbound/etc/unbound/forward-records.conf
 
     # OPTIONAL:
-    # Forward Secure DNS to upstread provider Cloudflare DNS
+    # Forward Secure DNS to upstream provider Cloudflare DNS
 
     # forward-zone:
     #     name: "."


### PR DESCRIPTION
Verbosity Level to log only the errors according to the [unbound's documentation](https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound.conf.html#term-verbosity-number) is `0`.

While the `unbound.conf` in the project mentioned "only log errors" in the comments, it logged operational info as well. So, changed it to 0.

Also fixed a minor typo.

Edit:
I realise now that the logs are redirected to `/dev/null` anyway.