### PR TITLE
README 📝 add details for custom DNS provider(s) + renamed deprecated environment variable 'DNSx' to 'PIHOLE_DNS_x'

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: IAmStoxe
+custom: "https://www.buymeacoffee.com/stoxe"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+wireguard/
+unbound/*
+etc-pihole/
+etc-dnsmasq.d/
+!unbound/unbound.conf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ unbound/*
 etc-pihole/
 etc-dnsmasq.d/
 !unbound/unbound.conf
+config/
+db/
+.env*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ The templates used for server and peer confs are saved under /config/templates. 
 ### Where can I get additional block lists?
 * [The Big Blocklist Collection](https://firebog.net/)
 
-
+### Commonly whitelisted domains
+* [Pi-Hole Community List](https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212)
+* [anudeepND Whitelist](https://github.com/anudeepND/whitelist)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,16 @@ Provided your DNS is properly configured on the device you're using, and you're 
 
 ## FAQ
 
-### [How do you add client configurations?](https://github.com/IAmStoxe/wirehole/issues/2#issuecomment-691294254)
+### [How do you add client configurations?
+If the environment variable `PEERS` is set to a number, the container will run in server mode and the necessary server and peer/client confs will be generated. The peer/client config qr codes will be output in the docker log. They will also be saved in text and png format under /config/peerX.
+
+Variables `SERVERURL`, `SERVERPORT`, `INTERNAL_SUBNET` and `PEERDNS` are optional variables used for server mode. Any changes to these environment variables will trigger regeneration of server and peer confs. Peer/client confs will be recreated with existing private/public keys. Delete the peer folders for the keys to be recreated along with the confs.
+
+To add more peers/clients later on, you increment the `PEERS` environment variable and recreate the container.
+
+To display the QR codes of active peers again, you can use the following command and list the peer numbers as arguments: `docker-compose exec -it wireguard /app/show-peer 1 4 5` will show peers #1 #4 and #5 (Keep in mind that the QR codes are also stored as PNGs in the config folder).
+
+The templates used for server and peer confs are saved under /config/templates. Advanced users can modify these templates and force conf generation by deleting /config/wg0.conf and restarting the container.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Variables `SERVERURL`, `SERVERPORT`, `INTERNAL_SUBNET` and `PEERDNS` are optiona
 
 To add more peers/clients later on, you increment the `PEERS` environment variable and recreate the container.
 
-To display the QR codes of active peers again, you can use the following command and list the peer numbers as arguments: `docker-compose exec -it wireguard /app/show-peer 1 4 5` will show peers #1 #4 and #5 (Keep in mind that the QR codes are also stored as PNGs in the config folder).
+To display the QR codes of active peers again, you can use the following command and list the peer numbers as arguments: `docker-compose exec wireguard /app/show-peer 1 4 5` will show peers #1 #4 and #5 (Keep in mind that the QR codes are also stored as PNGs in the config folder).
 
 The templates used for server and peer confs are saved under /config/templates. Advanced users can modify these templates and force conf generation by deleting /config/wg0.conf and restarting the container.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 - ☁ If using a cloud provider:
     - You need to allow ingress to port `51820`
 
+##### Optional Fully Automated Deployment on Oracle Cloud:
+  - https://medium.com/@devinjaystokes/automating-the-deployment-of-your-forever-free-pihole-and-wireguard-server-dce581f71b7
+
 To get started all you need to do is clone the repository and spin up the containers.
 
 ### Quickstart

--- a/README.md
+++ b/README.md
@@ -177,13 +177,19 @@ Providers they have the information for:
 
 ---
 
-## (Optional) Setting a DNS record for pihole
+## Setting a DNS record for pihole
 1. Login to pihole admin
 2. Navigate to "Local Records"
 3. Fill out the form like the image below
 ![Image](https://i.imgur.com/PM1kwcf.png)
 
 Provided your DNS is properly configured on the device you're using, and you're connected to WireGuard, you can now navigate to http://pi.hole/admin and it should take you right to the pihole admin interface.
+
+---
+
+## FAQ
+
+### [How do you add client configurations?](https://github.com/IAmStoxe/wirehole/issues/2#issuecomment-691294254)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Provided your DNS is properly configured on the device you're using, and you're 
 
 ## FAQ
 
-### [How do you add client configurations?
+### How do you add client configurations?
 If the environment variable `PEERS` is set to a number, the container will run in server mode and the necessary server and peer/client confs will be generated. The peer/client config qr codes will be output in the docker log. They will also be saved in text and png format under /config/peerX.
 
 Variables `SERVERURL`, `SERVERPORT`, `INTERNAL_SUBNET` and `PEERDNS` are optional variables used for server mode. Any changes to these environment variables will trigger regeneration of server and peer confs. Peer/client confs will be recreated with existing private/public keys. Delete the peer folders for the keys to be recreated along with the confs.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The templates used for server and peer confs are saved under /config/templates. 
 * [anudeepND Whitelist](https://github.com/anudeepND/whitelist)
 
 ### Why do you use Unbound / What benefit is there to using Unbound?
-[PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide]
+[PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Providers they have the information for:
 
 ---
 
+## (Optional) Setting a DNS record for pihole
+1. Login to pihole admin
+2. Navigate to "Local Records"
+3. Fill out the form like the image below
+![Image](https://i.imgur.com/PM1kwcf.png)
+
+Provided your DNS is properly configured on the device you're using, and you're connected to WireGuard, you can now navigate to http://pi.hole/admin and it should take you right to the pihole admin interface.
+
+---
+
 ## Author
 
 👤 **Devin Stokes**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## What is this?
+WireHole is a combination of WireGuard, PiHole, and Unbound in a docker-compose project with the intent of enabling users to quickly and easily create and deploy a personally managed full or split-tunnel WireGuard VPN with ad blocking capabilities (via Pihole), and DNS caching with additional privacy options (via Unbound). 
+
+---
+
 
 ## Prerequisites:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 
 ## Prerequisites:
 
-- 💻 **Installed**: **docker** and **docker-compose**
 - ☁ If using a cloud provider:
     - You need to allow ingress to port `51820`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## What is this?
-WireHole is a combination of WireGuard, Pi-hole, and Unbound in a docker-compose project with the intent of enabling users to quickly and easily create and deploy a personally managed full or split-tunnel WireGuard VPN with ad blocking capabilities (via Pi-hole), and DNS caching with additional privacy options (via Unbound). 
+WireHole is a combination of WireGuard, PiHole, and Unbound in a docker-compose project with the intent of enabling users to quickly and easily create and deploy a personally managed full or split-tunnel WireGuard VPN with ad blocking capabilities (via Pihole), and DNS caching with additional privacy options (via Unbound). 
 
 ## Prerequisites:
 
@@ -112,7 +112,7 @@ Modify your wireguard client `AllowedIps` to `10.2.0.0/24` to only tunnel the we
 
 ---
 
-## Access Pi-hole
+## Access PiHole
 
 While connected to WireGuard, navigate to http://10.2.0.100/admin
 
@@ -179,13 +179,13 @@ Providers they have the information for:
 
 ---
 
-## Setting a DNS record for Pi-hole
-1. Login to Pi-hole admin
+## Setting a DNS record for pihole
+1. Login to pihole admin
 2. Navigate to "Local Records"
 3. Fill out the form like the image below
 ![Image](https://i.imgur.com/PM1kwcf.png)
 
-Provided your DNS is properly configured on the device you're using, and you're connected to WireGuard, you can now navigate to http://pi.hole/admin and it should take you right to the Pi-hole admin interface.
+Provided your DNS is properly configured on the device you're using, and you're connected to WireGuard, you can now navigate to http://pi.hole/admin and it should take you right to the pihole admin interface.
 
 ---
 
@@ -206,11 +206,11 @@ The templates used for server and peer confs are saved under /config/templates. 
 * [The Big Blocklist Collection](https://firebog.net/)
 
 ### Commonly whitelisted domains
-* [Pi-hole Community List](https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212)
+* [Pi-Hole Community List](https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212)
 * [anudeepND Whitelist](https://github.com/anudeepND/whitelist)
 
 ### Why do you use Unbound / What benefit is there to using Unbound?
-* [Pi-hole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
+* [PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## What is this?
-WireHole is a combination of WireGuard, PiHole, and Unbound in a docker-compose project with the intent of enabling users to quickly and easily create and deploy a personally managed full or split-tunnel WireGuard VPN with ad blocking capabilities (via Pihole), and DNS caching with additional privacy options (via Unbound). 
+WireHole is a combination of WireGuard, Pi-hole, and Unbound in a docker-compose project with the intent of enabling users to quickly and easily create and deploy a personally managed full or split-tunnel WireGuard VPN with ad blocking capabilities (via Pi-hole), and DNS caching with additional privacy options (via Unbound). 
 
 ## Prerequisites:
 
@@ -112,7 +112,7 @@ Modify your wireguard client `AllowedIps` to `10.2.0.0/24` to only tunnel the we
 
 ---
 
-## Access PiHole
+## Access Pi-hole
 
 While connected to WireGuard, navigate to http://10.2.0.100/admin
 
@@ -179,13 +179,13 @@ Providers they have the information for:
 
 ---
 
-## Setting a DNS record for pihole
-1. Login to pihole admin
+## Setting a DNS record for Pi-hole
+1. Login to Pi-hole admin
 2. Navigate to "Local Records"
 3. Fill out the form like the image below
 ![Image](https://i.imgur.com/PM1kwcf.png)
 
-Provided your DNS is properly configured on the device you're using, and you're connected to WireGuard, you can now navigate to http://pi.hole/admin and it should take you right to the pihole admin interface.
+Provided your DNS is properly configured on the device you're using, and you're connected to WireGuard, you can now navigate to http://pi.hole/admin and it should take you right to the Pi-hole admin interface.
 
 ---
 
@@ -206,11 +206,11 @@ The templates used for server and peer confs are saved under /config/templates. 
 * [The Big Blocklist Collection](https://firebog.net/)
 
 ### Commonly whitelisted domains
-* [Pi-Hole Community List](https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212)
+* [Pi-hole Community List](https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212)
 * [anudeepND Whitelist](https://github.com/anudeepND/whitelist)
 
 ### Why do you use Unbound / What benefit is there to using Unbound?
-* [PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
+* [Pi-hole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ WireHole is a combination of WireGuard, PiHole, and Unbound in a docker-compose 
 
 ## 🤝 Contributing
 
-Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/IAmStoxe/wirehole/issue). 
+Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/IAmStoxe/wirehole/issues). 
 
 ## Show your support
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,58 @@
 
 To get started all you need to do is clone the repository and spin up the containers.
 
+### Quickstart
 ```bash
 git clone https://github.com/IAmStoxe/wirehole.git
 cd wirehole
 docker-compose up
 ```
+### Full Setup
+```bash
+#!/bin/bash
+
+# Prereqs and docker
+sudo apt-get update &&
+    sudo apt-get install -yqq \
+        curl \
+        git \
+        apt-transport-https \
+        ca-certificates \
+        gnupg-agent \
+        software-properties-common
+
+# Install Docker repository and keys
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+sudo add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) \
+        stable" &&
+    sudo apt-get update &&
+    sudo apt-get install docker-ce docker-ce-cli containerd.io -yqq
+
+# docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose &&
+    sudo chmod +x /usr/local/bin/docker-compose &&
+    sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+
+# Fix dns issues
+sudo systemctl stop systemd-resolved
+
+sudo sed -i 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf &&
+    sudo sed -i 's/^#DNS=.*/DNS=1.1.1.1/g' /etc/systemd/resolved.conf &&
+    sudo systemctl stop systemd-resolved &&
+    sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
+sudo systemctl start systemd-resolved
+
+# wirehole
+git clone https://github.com/IAmStoxe/wirehole.git &&
+    cd wirehole &&
+    docker-compose up
+
+```
+
 
 Within the output of the terminal will be QR codes you can (if you choose) to setup it WireGuard on your phone.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ WireHole is a combination of WireGuard, PiHole, and Unbound in a docker-compose 
 
 ##### Optional Fully Automated Deployment on Oracle Cloud:
   - https://medium.com/@devinjaystokes/automating-the-deployment-of-your-forever-free-pihole-and-wireguard-server-dce581f71b7
-  
+ 
+## Author
+
+👤 **Devin Stokes**
+
+* Twitter: [@DevinStokes](https://twitter.com/DevinStokes)
+* Github: [@IAmStoxe](https://github.com/IAmStoxe)
+
+## 🤝 Contributing
+
+Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/IAmStoxe/wirehole/issue). 
+
+## Show your support
+
+Give a ⭐ if this project helped you!
+
+<a href="https://www.buymeacoffee.com/stoxe" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-orange.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+ 
 ---
 
 ### Quickstart
@@ -213,20 +230,3 @@ The templates used for server and peer confs are saved under /config/templates. 
 * [PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
 
 ---
-
-## Author
-
-👤 **Devin Stokes**
-
-* Twitter: [@DevinStokes](https://twitter.com/DevinStokes)
-* Github: [@IAmStoxe](https://github.com/IAmStoxe)
-
-## 🤝 Contributing
-
-Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/IAmStoxe/wirehole/issue). 
-
-## Show your support
-
-Give a ⭐ if this project helped you!
-
-<a href="https://www.buymeacoffee.com/stoxe" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-orange.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/README.md
+++ b/README.md
@@ -129,3 +129,24 @@ wireguard:
       # ...
  # ...
 ```
+
+---
+
+
+## Author
+
+👤 **Devin Stokes**
+
+* Twitter: [@DevinStokes](https://twitter.com/DevinStokes)
+* Github: [@IAmStoxe](https://github.com/IAmStoxe)
+
+## 🤝 Contributing
+
+Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/IAmStoxe/urlgrab/issue). 
+
+## Show your support
+
+Give a ⭐ if this project helped you!
+
+<a href="https://www.buymeacoffee.com/stoxe" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" style="height: 51px !important;width: 217px !important;" ></a>
+

--- a/README.md
+++ b/README.md
@@ -111,3 +111,21 @@ While connected to WireGuard, navigate to http://10.2.0.100/admin
 *The password (unless you set it in `docker-compose.yml`) is blank.*
 
 ![](https://i.imgur.com/hlHL6VA.png)
+
+---
+
+## Configuring for Dynamic DNS (DDNS)
+If you're using a dynamic DNS provider, you can edit `docker-compose.yml` under "wireguard". 
+Here is an excerpt from the file. 
+
+You need to uncomment `#- SERVERURL` so it reads `- SERVERURL` without the `#` and then change `my.ddns.net` to your DDNS URL.
+
+```yaml
+wireguard:
+   # ...
+    environment:
+      # ...
+      - SERVERURL=my.ddns.net #optional - For use with DDNS (Uncomment to use)
+      # ...
+ # ...
+```

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ wireguard:
 
 ## 🤝 Contributing
 
-Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/IAmStoxe/urlgrab/issue). 
+Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/IAmStoxe/wirehole/issue). 
 
 ## Show your support
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,19 @@ Providers they have the information for:
 5. DNS.WATCH
 6. Quad9
 7. CloudFlare DNS
+8. Custom
 
+> With custom, you'll choose your favorite DNS provider. If you care about Internet independence and privacy, we suggest having a look at the [OpenNIC DNS Project](https://servers.opennic.org/).
+
+Please add your custom DNS provider(s) in your customized `[docker-compose.yml](docker-compose.yml#L68)` as an [Optional Variable](https://github.com/pi-hole/docker-pi-hole/blob/master/README.md#optional-variables) or directly in Pi-hole's `setupVars.conf` with an example of NextDNS.io resolvers for IPv4 and IPv6:
+```
+PIHOLE_DNS_1=45.90.28.39
+PIHOLE_DNS_2=45.90.30.39
+PIHOLE_DNS_3=2a07:a8c0::75:86b2
+PIHOLE_DNS_4=2a07:a8c1::75:86b2
+```
+
+If you are also caring for **performance and reliability** of the DNS provider you choose, you might be interested in [dnsping_rrd](https://github.com/thomasmerz/dnsping_rrd) which monitors the average response times of DNS resolvers in RRD databases and simple HTML pages with PNG graphs. After some days you will have a solid base for choosing the fastest and most reliable for your internet connection.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@
 
 ##### Optional Fully Automated Deployment on Oracle Cloud:
   - https://medium.com/@devinjaystokes/automating-the-deployment-of-your-forever-free-pihole-and-wireguard-server-dce581f71b7
-
-To get started all you need to do is clone the repository and spin up the containers.
+  
+---
 
 ### Quickstart
+To get started all you need to do is clone the repository and spin up the containers.
+
 ```bash
 git clone https://github.com/IAmStoxe/wirehole.git
 cd wirehole

--- a/README.md
+++ b/README.md
@@ -42,16 +42,6 @@ sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-
     sudo chmod +x /usr/local/bin/docker-compose &&
     sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 
-# Fix dns issues
-sudo systemctl stop systemd-resolved
-
-sudo sed -i 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf &&
-    sudo sed -i 's/^#DNS=.*/DNS=1.1.1.1/g' /etc/systemd/resolved.conf &&
-    sudo systemctl stop systemd-resolved &&
-    sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-
-sudo systemctl start systemd-resolved
-
 # wirehole
 git clone https://github.com/IAmStoxe/wirehole.git &&
     cd wirehole &&

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ To display the QR codes of active peers again, you can use the following command
 
 The templates used for server and peer confs are saved under /config/templates. Advanced users can modify these templates and force conf generation by deleting /config/wg0.conf and restarting the container.
 
+### Where can I get additional block lists?
+* [The Big Blocklist Collection](https://firebog.net/)
+
+
+
 ---
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -102,9 +102,13 @@ wireguard    | [cont-init.d] done.
 wireguard    | [services.d] starting services
 ```
 
+---
+
 ## Recommended configuration / Split tunnel:
 
 Modify your wireguard client `AllowedIps` to `10.2.0.0/24` to only tunnel the web panel and DNS traffic.
+
+---
 
 ## Access PiHole
 
@@ -134,6 +138,44 @@ wireguard:
 
 ---
 
+## Modifying the upstream DNS provider for Unbound
+If you choose to not use Cloudflare any reason you are able to modify the upstream DNS provider in `unbound.conf`.
+
+Search for `forward-zone` and modify the IP addresses for your chosen DNS provider.
+
+>**NOTE:** The anything after `#` is a comment on the line. 
+What this means is it is just there to tell you which DNS provider you put there. It is for you to be able to reference later. I recommend updating this if you change your DNS provider from the default values.
+
+
+```yaml
+forward-zone:
+        name: "."
+        forward-addr: 1.1.1.1@853#cloudflare-dns.com
+        forward-addr: 1.0.0.1@853#cloudflare-dns.com
+        forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
+        forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
+        forward-tls-upstream: yes
+```
+
+---
+
+## Available DNS Providers
+
+While you can actually use any upstream provider you want, the team over at pi-hole.net provide a fantastic break down along with all needed information of some of the more popular providers here:
+https://docs.pi-hole.net/guides/upstream-dns-providers/
+
+Providers they have the information for:
+
+1. Google
+2. OpenDNS
+3. Level3
+4. Comodo
+5. DNS.WATCH
+6. Quad9
+7. CloudFlare DNS
+
+
+---
 
 ## Author
 
@@ -150,5 +192,4 @@ Contributions, issues and feature requests are welcome!<br />Feel free to check 
 
 Give a ⭐ if this project helped you!
 
-<a href="https://www.buymeacoffee.com/stoxe" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" style="height: 51px !important;width: 217px !important;" ></a>
-
+<a href="https://www.buymeacoffee.com/stoxe" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-orange.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The templates used for server and peer confs are saved under /config/templates. 
 * [anudeepND Whitelist](https://github.com/anudeepND/whitelist)
 
 ### Why do you use Unbound / What benefit is there to using Unbound?
-[PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
+* [PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 ## What is this?
 WireHole is a combination of WireGuard, PiHole, and Unbound in a docker-compose project with the intent of enabling users to quickly and easily create and deploy a personally managed full or split-tunnel WireGuard VPN with ad blocking capabilities (via Pihole), and DNS caching with additional privacy options (via Unbound). 
 
-## Prerequisites:
-
-- ☁ If using a cloud provider:
-    - You need to allow ingress to port `51820`
-
-##### Optional Fully Automated Deployment on Oracle Cloud:
-  - https://medium.com/@devinjaystokes/automating-the-deployment-of-your-forever-free-pihole-and-wireguard-server-dce581f71b7
- 
 ## Author
 
 👤 **Devin Stokes**
@@ -27,6 +19,30 @@ Give a ⭐ if this project helped you!
 <a href="https://www.buymeacoffee.com/stoxe" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-orange.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
  
 ---
+
+
+### Supported Architectures
+
+The Wireguard image supports multiple architectures such as `x86-64`, `arm64` and `armhf`. Linuxserver - who makes the wireguard image we use - utilises the docker manifest for multi-platform awareness. 
+
+More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and LinuxServer's announcement [here](https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/).
+
+Simply pulling `linuxserver/wireguard` should retrieve the correct image for your arch, but you can also pull specific arch images via tags 
+
+> *This is the default configuration in this project*
+
+**The architectures supported by this image are:**
+
+| Architecture | Tag |
+| :----: | --- |
+| x86-64 | amd64-latest |
+| arm64 | arm64v8-latest |
+| armhf | arm32v7-latest |
+
+
+##### Optional - Fully Automated Deployment on Oracle Cloud:
+  - https://medium.com/@devinjaystokes/automating-the-deployment-of-your-forever-free-pihole-and-wireguard-server-dce581f71b7
+ 
 
 ### Quickstart
 To get started all you need to do is clone the repository and spin up the containers.
@@ -156,6 +172,72 @@ wireguard:
 ```
 
 ---
+## Configuring / Parameters
+
+Container images are configured using parameters passed at runtime (such as those above). These parameters are separated by a colon and indicate `<external>:<internal>` respectively. For example, `-p 8080:80` would expose port `80` from inside the container to be accessible from the host's IP on port `8080` outside the container.
+
+| Parameter | Function |
+| :----: | --- |
+| `-p 51820/udp` | wireguard port |
+| `-e PUID=1000` | for UserID - see below for explanation |
+| `-e PGID=1000` | for GroupID - see below for explanation |
+| `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
+| `-e SERVERURL=wireguard.domain.com` | External IP or domain name for docker host. Used in server mode. If set to `auto`, the container will try to determine and set the external IP automatically |
+| `-e SERVERPORT=51820` | External port for docker host. Used in server mode. |
+| `-e PEERS=1` | Number of peers to create confs for. Required for server mode. Can be a list of names too: myPC,myPhone,myTablet... |
+| `-e PEERDNS=auto` | DNS server set in peer/client configs (can be set as `8.8.8.8`). Used in server mode. Defaults to `auto`, which uses wireguard docker host's DNS via included CoreDNS forward. |
+| `-e INTERNAL_SUBNET=10.13.13.0` | Internal subnet for the wireguard and server and peers (only change if it clashes). Used in server mode. |
+| `-e ALLOWEDIPS=0.0.0.0/0` | The IPs/Ranges that the peers will be able to reach using the VPN connection. If not specified the default value is: '0.0.0.0/0, ::0/0' This will cause ALL traffic to route through the VPN, if you want split tunneling, set this to only the IPs you would like to use the tunnel AND the ip of the server's WG ip, such as 10.13.13.1. |
+| `-v /config` | Contains all relevant configuration files. |
+| `-v /lib/modules` | Maps host's modules folder. |
+| `--sysctl=` | Required for client mode. |
+
+### Environment variables from files (Docker secrets)
+
+You can set any environment variable from a file by using a special prepend `FILE__`.
+
+As an example:
+
+```bash
+-e FILE__PASSWORD=/run/secrets/mysecretpassword
+```
+
+Will set the environment variable `PASSWORD` based on the contents of the `/run/secrets/mysecretpassword` file.
+
+### Umask for running applications
+
+There is the ability to override the default umask settings for services started within the containers using the optional `-e UMASK=022` setting.
+Keep in mind umask is not chmod it subtracts from permissions based on it's value it does not add. Please read up [here](https://en.wikipedia.org/wiki/Umask) before asking for support.
+
+### User / Group Identifiers
+
+When using volumes (`-v` flags) permissions issues can arise between the host OS and the container, this is avoided by allowing you to specify the user `PUID` and group `PGID`.
+
+Ensure any volume directories on the host are owned by the same user you specify and any permissions issues will vanish like magic.
+
+In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as below:
+
+```bash
+  $ id username
+    uid=1000(dockeruser) gid=1000(dockergroup) groups=1000(dockergroup)
+```
+
+---
+
+## Adding Clients
+If the environment variable `PEERS` is set to a number or a list of strings separated by comma, the container will run in server mode and the necessary server and peer/client confs will be generated. The peer/client config qr codes will be output in the docker log. They will also be saved in text and png format under `/config/peerX` in case `PEERS` is a variable and an integer or `/config/peer_X` in case a list of names was provided instead of an integer.
+
+Variables `SERVERURL`, `SERVERPORT`, `INTERNAL_SUBNET` and `PEERDNS` are optional variables used for server mode. Any changes to these environment variables will trigger regeneration of server and peer confs. Peer/client confs will be recreated with existing private/public keys. Delete the peer folders for the keys to be recreated along with the confs.
+
+To add more peers/clients later on, you increment the `PEERS` environment variable or add more elements to the list and recreate the container.
+
+To display the QR codes of active peers again, you can use the following command and list the peer numbers as arguments: `docker exec -it wireguard /app/show-peer 1 4 5` or `docker exec -it wireguard /app/show-peer myPC myPhone myTablet` (Keep in mind that the QR codes are also stored as PNGs in the config folder).
+
+The templates used for server and peer confs are saved under `/config/templates`. Advanced users can modify these templates and force conf generation by deleting `/config/wg0.conf` and restarting the container.
+
+*(This portion of documentation has been adapted from [docker-wireguard](https://github.com/linuxserver/docker-wireguard/blob/master/README.md))*
+
+---
 
 ## Modifying the upstream DNS provider for Unbound
 If you choose to not use Cloudflare any reason you are able to modify the upstream DNS provider in `unbound.conf`.
@@ -205,6 +287,50 @@ Providers they have the information for:
 Provided your DNS is properly configured on the device you're using, and you're connected to WireGuard, you can now navigate to http://pi.hole/admin and it should take you right to the pihole admin interface.
 
 ---
+## Support Info
+
+* Shell access whilst the container is running: `docker exec -it wireguard /bin/bash`
+* To monitor the logs of the container in realtime: `docker logs -f wireguard`
+* container version number
+  * `docker inspect -f '{{ index .Config.Labels "build_version" }}' wireguard`
+* image version number
+  * `docker inspect -f '{{ index .Config.Labels "build_version" }}' ghcr.io/linuxserver/wireguard`
+
+---
+
+## Updating Info
+
+LinuxServer images are generally static, versioned, and require an image update and container recreation to update the app inside. 
+> **Note:** Updating apps inside the container is NOT supported.
+
+Below are the instructions for updating **containers**:
+
+### Via Docker Compose
+
+* Update all images: `docker-compose pull`
+  * or update a single image: `docker-compose pull wireguard`
+* Let compose update all containers as necessary: `docker-compose up -d`
+  * or update a single container: `docker-compose up -d wireguard`
+* You can also remove the old dangling images: `docker image prune`
+
+### Via Watchtower auto-updater (only use if you don't remember the original parameters)
+
+* Pull the latest image at its tag and replace it with the same env variables in one run:
+
+  ```bash
+  docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower \
+  --run-once wireguard
+  ```
+
+* You can also remove the old dangling images: `docker image prune`
+
+> **Note:** Watchtower is not endorsed as a solution for automated updates of existing Docker containers. In fact generally automated updates are discouraged. However, this is a useful tool for one-time manual updates of containers where you have forgotten the original parameters. In the long term, LinuxServer.io highly recommends using Docker Compose.
+
+
+---
+
 
 ## FAQ
 
@@ -219,6 +345,16 @@ To display the QR codes of active peers again, you can use the following command
 
 The templates used for server and peer confs are saved under /config/templates. Advanced users can modify these templates and force conf generation by deleting /config/wg0.conf and restarting the container.
 
+### Can I build ARM variants on x86_64?
+
+The ARM variants can be built on x86_64 hardware using `multiarch/qemu-user-static`
+
+```bash
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+```
+
+Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
+
 ### Where can I get additional block lists?
 * [The Big Blocklist Collection](https://firebog.net/)
 
@@ -230,3 +366,18 @@ The templates used for server and peer confs are saved under /config/templates. 
 * [PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide)
 
 ---
+
+## Networking Considerations
+
+If you plan to use Wireguard both remotely and locally, say on your mobile phone, you will need to consider routing. Most firewalls will not route ports forwarded on your WAN interface correctly to the LAN out of the box. This means that when you return home, even though you can see the Wireguard server, the return packets will probably get lost.
+
+This is not a Wireguard specific issue and the two generally accepted solutions are NAT reflection (setting your edge router/firewall up in such a way as it translates internal packets correctly) or split horizon DNS (setting your internal DNS to return the private rather than public IP when connecting locally).
+
+Both of these approaches have positives and negatives however their setup is out of scope for this document as everyone's network layout and equipment will be different.
+
+
+---
+
+###### Shout out to LinuxServer.io for their documentation and maintenance of the incredible Wireguard image.
+
+--- 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 ## What is this?
 WireHole is a combination of WireGuard, PiHole, and Unbound in a docker-compose project with the intent of enabling users to quickly and easily create and deploy a personally managed full or split-tunnel WireGuard VPN with ad blocking capabilities (via Pihole), and DNS caching with additional privacy options (via Unbound). 
 
----
-
-
 ## Prerequisites:
 
 - ☁ If using a cloud provider:
@@ -211,6 +208,9 @@ The templates used for server and peer confs are saved under /config/templates. 
 ### Commonly whitelisted domains
 * [Pi-Hole Community List](https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212)
 * [anudeepND Whitelist](https://github.com/anudeepND/whitelist)
+
+### Why do you use Unbound / What benefit is there to using Unbound?
+[PiHole Official Site: What does this guide provide?](https://docs.pi-hole.net/guides/unbound/#what-does-this-guide-provide]
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Within the output of the terminal will be QR codes you can (if you choose) to se
 
 ```bash
 wireguard    | **** Internal subnet is set to 10.6.0.0 ****
-wireguard    | **** Peer DNS servers will be set to 10.1.0.100 ****
+wireguard    | **** Peer DNS servers will be set to 10.2.0.100 ****
 wireguard    | **** No found wg0.conf found (maybe an initial install), generating 1 server and 1 peer/client confs ****
 wireguard    | PEER 1 QR code:
 wireguard    | █████████████████████████████████████████████████████████████████

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ wireguard    | [services.d] starting services
 
 ## Recommended configuration / Split tunnel:
 
-Modify your wireguard client `AllowedIps` to `10.1.0.0/24` to only tunnel the web panel and DNS traffic.
+Modify your wireguard client `AllowedIps` to `10.2.0.0/24` to only tunnel the web panel and DNS traffic.
 
 ## Access PiHole
 
-While connected to WireGuard, navigate to http://10.1.0.100/admin
+While connected to WireGuard, navigate to http://10.2.0.100/admin
 
 *The password (unless you set it in `docker-compose.yml`) is blank.*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,28 @@
 version: "3"
 
 networks:
-  piguard:
+  private_network:
     ipam:
       driver: default
       config:
         - subnet: 10.1.0.0/24
+
 services:
+  unbound:
+    image: "mvance/unbound:latest"
+    container_name: unbound
+    restart: unless-stopped
+    # ports:
+    #   - "53:53/tcp"
+    #   - "53:53/udp"
+    volumes:
+      - "./unbound:/opt/unbound/etc/unbound/"
+    networks:
+      private_network:
+        ipv4_address: 10.1.0.200
+
   wireguard:
-    depends_on: [unbound]
-    privileged: false
+    depends_on: [unbound, pihole]
     image: linuxserver/wireguard
     container_name: wireguard
     cap_add:
@@ -20,53 +33,45 @@ services:
       - PGID=1000
       - TZ=America/Los_Angeles
       # - SERVERURL=wireguard.domain.com #optional
-      - SERVERPORT=5555 #optional
-      - PEERS=1 #optional
+      - SERVERPORT=51820 #optional
+      - PEERS=1 #optional - How many peers to generate for you (clients)
       - PEERDNS=10.1.0.100 # Set it to point to pihole
-      - INTERNAL_SUBNET=10.6.0.0 #optional
+      - INTERNAL_SUBNET=10.6.0.0
     volumes:
       - ./wireguard:/config
       - /lib/modules:/lib/modules
     ports:
-      - 5555:51820/udp
+      - "51820:51820/udp"
+    dns:
+      - 10.1.0.100 # Points to pihole
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped
     networks:
-      piguard:
+      private_network:
         ipv4_address: 10.1.0.3
-
-  unbound:
-    container_name: unbound
-    privileged: false
-    volumes:
-      - "./unbound:/opt/unbound/etc/unbound/"
-    # ports:
-    #   - "53:53/tcp"
-    #   - "53:53/udp"
-    restart: unless-stopped
-    image: "mvance/unbound:latest"
-    networks:
-      piguard:
-        ipv4_address: 10.1.0.200
 
   pihole:
     depends_on: [unbound]
     container_name: pihole
     image: pihole/pihole:latest
-    privileged: false
+    restart: unless-stopped
+    privileged: true
     ports:
       - "53:53/tcp"
       - "53:53/udp"
       # - "67:67/udp" # Uncomment for pihole dhcp
       - "80:80/tcp"
       - "443:443/tcp"
+    dns:
+      - 10.1.0.200 # Points to unbound
+      - 1.1.1.1
     environment:
       TZ: "America/Los_Angeles"
-      WEBPASSWORD: ''
+      WEBPASSWORD: "" # Blank password - Can be whatever you want.
       ServerIP: 10.1.0.100
-      DNS1: 10.1.0.200
-      DNS2: 10.1.0.200
+      DNS1: 10.1.0.200 # Unbound IP
+      DNS2: 10.1.0.200 # If we don't specify two, it will auto pick google.
     # Volumes store your data between container upgrades
     volumes:
       - "./etc-pihole/:/etc/pihole/"
@@ -75,7 +80,6 @@ services:
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:
       - NET_ADMIN
-    restart: unless-stopped
     networks:
-      piguard:
+      private_network:
         ipv4_address: 10.1.0.100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
     image: "mvance/unbound:latest"
     container_name: unbound
     restart: unless-stopped
-    ports:
-      - "53/tcp"
-      - "53/udp"
     hostname: "unbound"
     volumes:
       - "./unbound:/opt/unbound/etc/unbound/"
@@ -49,6 +46,7 @@ services:
       - 10.2.0.200 # Points to unbound
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
+
     restart: unless-stopped
     networks:
       private_network:
@@ -60,12 +58,6 @@ services:
     image: pihole/pihole:latest
     restart: unless-stopped
     hostname: pihole
-    ports:
-      - "53/tcp"
-      - "53/udp"
-      # - "67:67/udp" # Uncomment for pihole dhcp
-      - "80/tcp"
-      - "443/tcp"
     dns:
       - 127.0.0.1
       - 10.2.0.200 # Points to unbound

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
     image: "mvance/unbound:latest"
     container_name: unbound
     restart: unless-stopped
-    # ports:
-    #   - "53:53/tcp"
-    #   - "53:53/udp"
+    ports:
+      - "53/tcp"
+      - "53/udp"
     volumes:
       - "./unbound:/opt/unbound/etc/unbound/"
     networks:
@@ -37,13 +37,14 @@ services:
       - PEERS=1 #optional - How many peers to generate for you (clients)
       - PEERDNS=10.1.0.100 # Set it to point to pihole
       - INTERNAL_SUBNET=10.6.0.0
+      
     volumes:
       - ./wireguard:/config
       - /lib/modules:/lib/modules
     ports:
       - "51820:51820/udp"
     dns:
-      - 10.1.0.100 # Points to pihole
+      - 10.1.0.100
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped
@@ -64,8 +65,8 @@ services:
       - "80:80/tcp"
       - "443:443/tcp"
     dns:
+      - 127.0.0.1
       - 10.1.0.200 # Points to unbound
-      - 1.1.1.1
     environment:
       TZ: "America/Los_Angeles"
       WEBPASSWORD: "" # Blank password - Can be whatever you want.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - PEERS=1 # How many peers to generate for you (clients)
       - PEERDNS=10.2.0.100 # Set it to point to pihole
       - INTERNAL_SUBNET=10.6.0.0
-      
+
     volumes:
       - ./wireguard:/config
       - /lib/modules:/lib/modules
@@ -65,8 +65,8 @@ services:
       TZ: "America/Los_Angeles"
       WEBPASSWORD: "" # Blank password - Can be whatever you want.
       ServerIP: 10.2.0.100 # Internal IP of pihole
-      DNS1: 10.2.0.200 # Unbound IP
-      DNS2: 10.2.0.200 # If we don't specify two, it will auto pick google.
+      PIHOLE_DNS_1: 10.2.0.200 # Unbound IP
+      PIHOLE_DNS_2: 10.2.0.200 # If we don't specify two, it will auto pick google.
     # Volumes store your data between container upgrades
     volumes:
       - "./etc-pihole/:/etc/pihole/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 10.1.0.0/24
+        - subnet: 10.2.0.0/24
 
 services:
   unbound:
@@ -15,11 +15,12 @@ services:
     ports:
       - "53/tcp"
       - "53/udp"
+    hostname: "unbound"
     volumes:
       - "./unbound:/opt/unbound/etc/unbound/"
     networks:
       private_network:
-        ipv4_address: 10.1.0.200
+        ipv4_address: 10.2.0.200
 
   wireguard:
     depends_on: [unbound, pihole]
@@ -31,11 +32,10 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=America/Los_Angeles
-      # - SERVERURL=wireguard.domain.com #optional
-      - SERVERPORT=51820 #optional
-      - PEERS=1 #optional - How many peers to generate for you (clients)
-      - PEERDNS=10.1.0.100 # Set it to point to pihole
+      - TZ=America/Los_Angeles # Change to your timezone
+      - SERVERPORT=51820
+      - PEERS=1 # How many peers to generate for you (clients)
+      - PEERDNS=10.2.0.100 # Set it to point to pihole
       - INTERNAL_SUBNET=10.6.0.0
       
     volumes:
@@ -44,35 +44,36 @@ services:
     ports:
       - "51820:51820/udp"
     dns:
-      - 10.1.0.100
+      - 10.2.0.100 # Points to pihole
+      - 10.2.0.200 # Points to unbound
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped
     networks:
       private_network:
-        ipv4_address: 10.1.0.3
+        ipv4_address: 10.2.0.3
 
   pihole:
     depends_on: [unbound]
     container_name: pihole
     image: pihole/pihole:latest
     restart: unless-stopped
-    privileged: true
+    hostname: pihole
     ports:
-      - "53:53/tcp"
-      - "53:53/udp"
+      - "53/tcp"
+      - "53/udp"
       # - "67:67/udp" # Uncomment for pihole dhcp
-      - "80:80/tcp"
-      - "443:443/tcp"
+      - "80/tcp"
+      - "443/tcp"
     dns:
       - 127.0.0.1
-      - 10.1.0.200 # Points to unbound
+      - 10.2.0.200 # Points to unbound
     environment:
       TZ: "America/Los_Angeles"
       WEBPASSWORD: "" # Blank password - Can be whatever you want.
-      ServerIP: 10.1.0.100
-      DNS1: 10.1.0.200 # Unbound IP
-      DNS2: 10.1.0.200 # If we don't specify two, it will auto pick google.
+      ServerIP: 10.1.0.100 # Internal IP of pihole
+      DNS1: 10.2.0.200 # Unbound IP
+      DNS2: 10.2.0.200 # If we don't specify two, it will auto pick google.
     # Volumes store your data between container upgrades
     volumes:
       - "./etc-pihole/:/etc/pihole/"
@@ -83,4 +84,4 @@ services:
       - NET_ADMIN
     networks:
       private_network:
-        ipv4_address: 10.1.0.100
+        ipv4_address: 10.2.0.100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - PGID=1000
       - TZ=America/Los_Angeles # Change to your timezone
       - SERVERPORT=51820
+      #- SERVERURL=my.ddns.net #optional - For use with DDNS (Uncomment to use)
       - PEERS=1 # How many peers to generate for you (clients)
       - PEERDNS=10.2.0.100 # Set it to point to pihole
       - INTERNAL_SUBNET=10.6.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     environment:
       TZ: "America/Los_Angeles"
       WEBPASSWORD: "" # Blank password - Can be whatever you want.
-      ServerIP: 10.1.0.100 # Internal IP of pihole
+      ServerIP: 10.2.0.100 # Internal IP of pihole
       DNS1: 10.2.0.200 # Unbound IP
       DNS2: 10.2.0.200 # If we don't specify two, it will auto pick google.
     # Volumes store your data between container upgrades

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -60,7 +60,7 @@ server:
     logfile: /dev/null
 
     # Only log errors
-    verbosity: 1
+    verbosity: 0
 
     ###########################################################################
     # PRIVACY SETTINGS
@@ -301,7 +301,7 @@ server:
     # include: /opt/unbound/etc/unbound/forward-records.conf
 
     # OPTIONAL:
-    # Forward Secure DNS to upstread provider Cloudflare DNS
+    # Forward Secure DNS to upstream provider Cloudflare DNS
 
     # forward-zone:
     #     name: "."

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -173,7 +173,7 @@ server:
     # (servfail). This stops recursive floods (e.g., random query names), but
     # not spoofed reflection floods. Cached responses are not rate limited by
     # this setting. Experimental option.
-    ratelimit: 1000
+    #ratelimit: 1000
 
     # Use this certificate bundle for authenticating connections made to
     # outside peers (e.g., auth-zone urls, DNS over TLS connections).
@@ -299,14 +299,17 @@ server:
     # ###########################################################################
 
     # include: /opt/unbound/etc/unbound/forward-records.conf
-    
-    forward-zone:
-        name: "."
-        forward-addr: 1.1.1.1@853#cloudflare-dns.com
-        forward-addr: 1.0.0.1@853#cloudflare-dns.com
-        forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
-        forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
-        forward-tls-upstream: yes
+
+    # OPTIONAL:
+    # Forward Secure DNS to upstread provider Cloudflare DNS
+
+    # forward-zone:
+    #     name: "."
+    #     forward-addr: 1.1.1.1@853#cloudflare-dns.com
+    #     forward-addr: 1.0.0.1@853#cloudflare-dns.com
+    #     forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
+    #     forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
+    #     forward-tls-upstream: yes
 
     remote-control:
         control-enable: no

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -302,7 +302,7 @@
 #     control-enable: no
 
 server:
-    verbosity: 5
+    verbosity: 1
     num-threads: 3
     interface: 0.0.0.0@53
     so-reuseport: yes

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -1,362 +1,302 @@
-# server:
-#     ###########################################################################
-#     # BASIC SETTINGS
-#     ###########################################################################
-#     # Time to live maximum for RRsets and messages in the cache. If the maximum
-#     # kicks in, responses to clients still get decrementing TTLs based on the
-#     # original (larger) values. When the internal TTL expires, the cache item
-#     # has expired. Can be set lower to force the resolver to query for data
-#     # often, and not trust (very large) TTL values.
-#     cache-max-ttl: 86400
-
-#     # Time to live minimum for RRsets and messages in the cache. If the minimum
-#     # kicks in, the data is cached for longer than the domain owner intended,
-#     # and thus less queries are made to look up the data. Zero makes sure the
-#     # data in the cache is as the domain owner intended, higher values,
-#     # especially more than an hour or so, can lead to trouble as the data in
-#     # the cache does not match up with the actual data any more.
-#     cache-min-ttl: 300
-
-#     # Set the working directory for the program.
-#     directory: "/opt/unbound/etc/unbound"
-
-#     # RFC 6891. Number of bytes size to advertise as the EDNS reassembly buffer
-#     # size. This is the value put into datagrams over UDP towards peers.
-#     # 4096 is RFC recommended. 1472 has a reasonable chance to fit within a
-#     # single Ethernet frame, thus lessing the chance of fragmentation
-#     # reassembly problems (usually seen as timeouts). Setting to 512 bypasses
-#     # even the most stringent path MTU problems, but is not recommended since
-#     # the amount of TCP fallback generated is excessive.
-#     edns-buffer-size: 1472
-
-#     # Listen to for queries from clients and answer from this network interface
-#     # and port.
-#     interface: 0.0.0.0@53
-
-#     # Rotates RRSet order in response (the pseudo-random number is taken from
-#     # the query ID, for speed and thread safety).
-#     rrset-roundrobin: yes
-
-#     # Drop user  privileges after  binding the port.
-#     username: "_unbound"
-
-#     ###########################################################################
-#     # LOGGING
-#     ###########################################################################
-
-#     # Do not print log lines to inform about local zone actions
-#     log-local-actions: no
-
-#     # Do not print one line per query to the log
-#     log-queries: no
-
-#     # Do not print one line per reply to the log
-#     log-replies: no
-
-#     # Do not print log lines that say why queries return SERVFAIL to clients
-#     log-servfail: no
-
-#     # Further limit logging
-#     logfile: /dev/null
-
-#     # Only log errors
-#     verbosity: 5
-
-#     ###########################################################################
-#     # PRIVACY SETTINGS
-#     ###########################################################################
-
-#     # RFC 8198. Use the DNSSEC NSEC chain to synthesize NXDO-MAIN and other
-#     # denials, using information from previous NXDO-MAINs answers. In other
-#     # words, use cached NSEC records to generate negative answers within a
-#     # range and positive answers from wildcards. This increases performance,
-#     # decreases latency and resource utilization on both authoritative and
-#     # recursive servers, and increases privacy. Also, it may help increase
-#     # resilience to certain DoS attacks in some circumstances.
-#     aggressive-nsec: yes
-
-#     # Extra delay for timeouted UDP ports before they are closed, in msec.
-#     # This prevents very delayed answer packets from the upstream (recursive)
-#     # servers from bouncing against closed ports and setting off all sort of
-#     # close-port counters, with eg. 1500 msec. When timeouts happen you need
-#     # extra sockets, it checks the ID and remote IP of packets, and unwanted
-#     # packets are added to the unwanted packet counter.
-#     delay-close: 10000
-
-#     # Prevent the unbound server from forking into the background as a daemon
-#     do-daemonize: no
-
-#     # Add localhost to the do-not-query-address list.
-#     do-not-query-localhost: no
-
-#     # Number  of  bytes size of the aggressive negative cache.
-#     neg-cache-size: 4M
-
-#     # Send minimum amount of information to upstream servers to enhance
-#     # privacy (best privacy).
-#     qname-minimisation: yes
-
-#     ###########################################################################
-#     # SECURITY SETTINGS
-#     ###########################################################################
-#     # Only give access to recursion clients from LAN IPs
-#     access-control: 127.0.0.1/32 allow
-#     access-control: 192.168.0.0/16 allow
-#     access-control: 172.16.0.0/12 allow
-#     access-control: 10.0.0.0/8 allow
-#     # access-control: fc00::/7 allow
-#     # access-control: ::1/128 allow
-
-#     # File with trust anchor for  one  zone, which is tracked with RFC5011
-#     # probes.
-#     auto-trust-anchor-file: "var/root.key"
-
-#     # Enable chroot (i.e, change apparent root directory for the current
-#     # running process and its children)
-#     chroot: "/opt/unbound/etc/unbound"
-
-#     # Deny queries of type ANY with an empty response.
-#     deny-any: yes
-
-#     # Harden against algorithm downgrade when multiple algorithms are
-#     # advertised in the DS record.
-#     harden-algo-downgrade: yes
-
-#     # RFC 8020. returns nxdomain to queries for a name below another name that
-#     # is already known to be nxdomain.
-#     harden-below-nxdomain: yes
-
-#     # Require DNSSEC data for trust-anchored zones, if such data is absent, the
-#     # zone becomes bogus. If turned off you run the risk of a downgrade attack
-#     # that disables security for a zone.
-#     harden-dnssec-stripped: yes
-
-#     # Only trust glue if it is within the servers authority.
-#     harden-glue: yes
-
-#     # Ignore very large queries.
-#     harden-large-queries: yes
-
-#     # Perform additional queries for infrastructure data to harden the referral
-#     # path. Validates the replies if trust anchors are configured and the zones
-#     # are signed. This enforces DNSSEC validation on nameserver NS sets and the
-#     # nameserver addresses that are encountered on the referral path to the
-#     # answer. Experimental option.
-#     harden-referral-path: no
-
-#     # Ignore very small EDNS buffer sizes from queries.
-#     harden-short-bufsize: yes
-
-#     # Refuse id.server and hostname.bind queries
-#     hide-identity: yes
-
-#     # Refuse version.server and version.bind queries
-#     hide-version: yes
-
-#     # Report this identity rather than the hostname of the server.
-#     identity: "DNS"
-
-#     # These private network addresses are not allowed to be returned for public
-#     # internet names. Any  occurrence of such addresses are removed from DNS
-#     # answers. Additionally, the DNSSEC validator may mark the  answers  bogus.
-#     # This  protects  against DNS  Rebinding
-#     private-address: 10.0.0.0/8
-#     private-address: 172.16.0.0/12
-#     private-address: 192.168.0.0/16
-#     private-address: 169.254.0.0/16
-#     # private-address: fd00::/8
-#     # private-address: fe80::/10
-#     # private-address: ::ffff:0:0/96
-
-#     # Enable ratelimiting of queries (per second) sent to nameserver for
-#     # performing recursion. More queries are turned away with an error
-#     # (servfail). This stops recursive floods (e.g., random query names), but
-#     # not spoofed reflection floods. Cached responses are not rate limited by
-#     # this setting. Experimental option.
-#     ratelimit: 1000
-
-#     # Use this certificate bundle for authenticating connections made to
-#     # outside peers (e.g., auth-zone urls, DNS over TLS connections).
-#     tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
-
-#     # Set the total number of unwanted replies to eep track of in every thread.
-#     # When it reaches the threshold, a defensive action of clearing the rrset
-#     # and message caches is taken, hopefully flushing away any poison.
-#     # Unbound suggests a value of 10 million.
-#     unwanted-reply-threshold: 10000
-
-#     # Use 0x20-encoded random bits in the query to foil spoof attempts. This
-#     # perturbs the lowercase and uppercase of query names sent to authority
-#     # servers and checks if the reply still has the correct casing.
-#     # This feature is an experimental implementation of draft dns-0x20.
-#     # Experimental option.
-#     use-caps-for-id: yes
-
-#     # Help protect users that rely on this validator for authentication from
-#     # potentially bad data in the additional section. Instruct the validator to
-#     # remove data from the additional section of secure messages that are not
-#     # signed properly. Messages that are insecure, bogus, indeterminate or
-#     # unchecked are not affected.
-#     val-clean-additional: yes
-
-#     ###########################################################################
-#     # PERFORMANCE SETTINGS
-#     ###########################################################################
-#     # https://nlnetlabs.nl/documentation/unbound/howto-optimise/
-#     # https://nlnetlabs.nl/news/2019/Feb/05/unbound-1.9.0-released/
-
-#     # Number of slabs in the infrastructure cache. Slabs reduce lock contention
-#     # by threads. Must be set to a power of 2.
-#     infra-cache-slabs: 4
-
-#     # Number of incoming TCP buffers to allocate per thread. Default
-#     # is 10. If set to 0, or if do-tcp is "no", no  TCP  queries  from
-#     # clients  are  accepted. For larger installations increasing this
-#     # value is a good idea.
-#     incoming-num-tcp: 10
-
-#     # Number of slabs in the key cache. Slabs reduce lock contention by
-#     # threads. Must be set to a power of 2. Setting (close) to the number
-#     # of cpus is a reasonable guess.
-#     key-cache-slabs: 4
-
-#     # Number  of  bytes  size  of  the  message  cache.
-#     # Unbound recommendation is to Use roughly twice as much rrset cache memory
-#     # as you use msg cache memory.
-#     msg-cache-size: 855658496
-
-#     # Number of slabs in the message cache. Slabs reduce lock contention by
-#     # threads. Must be set to a power of 2. Setting (close) to the number of
-#     # cpus is a reasonable guess.
-#     msg-cache-slabs: 4
-
-#     # The number of queries that every thread will service simultaneously. If
-#     # more queries arrive that need servicing, and no queries can be jostled
-#     # out (see jostle-timeout), then the queries are dropped.
-#     # This is best set at half the number of the outgoing-range.
-#     # This Unbound instance was compiled with libevent so it can efficiently
-#     # use more than 1024 file descriptors.
-#     num-queries-per-thread: 4096
-
-#     # The number of threads to create to serve clients.
-#     # This is set dynamically at run time to effectively use available CPUs
-#     # resources
-#     num-threads: 2
-
-#     # Number of ports to open. This number of file descriptors can be opened
-#     # per thread.
-#     # This Unbound instance was compiled with libevent so it can efficiently
-#     # use more than 1024 file descriptors.
-#     outgoing-range: 8192
-
-#     # Number of bytes size of the RRset cache.
-#     # Use roughly twice as much rrset cache memory as msg cache memory
-#     rrset-cache-size: 1711316992
-
-#     # Number of slabs in the RRset cache. Slabs reduce lock contention by
-#     # threads. Must be set to a power of 2.
-#     rrset-cache-slabs: 4
-
-#     # Do no insert authority/additional sections into response messages when
-#     # those sections are not required. This reduces response size
-#     # significantly, and may avoid TCP fallback for some responses. This may
-#     # cause a slight speedup.
-#     minimal-responses: yes
-
-#     # # Fetch the DNSKEYs earlier in the validation process, when a DS record
-#     # is encountered. This lowers the latency of requests at the expense of
-#     # little more CPU usage.
-#     prefetch: yes
-
-#     # Fetch the DNSKEYs earlier in the validation process, when a DS record is
-#     # encountered. This lowers the latency of requests at the expense of little
-#     # more CPU usage.
-#     prefetch-key: yes
-
-#     # Have unbound attempt to serve old responses from cache with a TTL of 0 in
-#     # the response without waiting for the actual resolution to finish. The
-#     # actual resolution answer ends up in the cache later on.
-#     serve-expired: yes
-
-#     # Open dedicated listening sockets for incoming queries for each thread and
-#     # try to set the SO_REUSEPORT socket option on each socket. May distribute
-#     # incoming queries to threads more evenly.
-#     so-reuseport: yes
-
-#     ###########################################################################
-#     # LOCAL ZONE
-#     ###########################################################################
-
-#     # # Include file for local-data and local-data-ptr
-#     # include: /opt/unbound/etc/unbound/a-records.conf
-#     # include: /opt/unbound/etc/unbound/srv-records.conf
-
-#     # ###########################################################################
-#     # # FORWARD ZONE
-#     # ###########################################################################
-
-#     # include: /opt/unbound/etc/unbound/forward-records.conf
-
-
-# remote-control:
-#     control-enable: no
-
 server:
-    verbosity: 1
-    num-threads: 3
-    interface: 0.0.0.0@53
-    so-reuseport: yes
-    edns-buffer-size: 1472
-    delay-close: 10000
-    cache-min-ttl: 60
+    ###########################################################################
+    # BASIC SETTINGS
+    ###########################################################################
+    # Time to live maximum for RRsets and messages in the cache. If the maximum
+    # kicks in, responses to clients still get decrementing TTLs based on the
+    # original (larger) values. When the internal TTL expires, the cache item
+    # has expired. Can be set lower to force the resolver to query for data
+    # often, and not trust (very large) TTL values.
     cache-max-ttl: 86400
-    do-daemonize: no
-    username: "_unbound"
-    log-queries: no
-    hide-version: yes
-    hide-identity: yes
-    identity: "DNS"
-    harden-algo-downgrade: yes
-    harden-short-bufsize: yes
-    harden-large-queries: yes
-    harden-glue: yes
-    harden-dnssec-stripped: yes
-    harden-below-nxdomain: yes
-    harden-referral-path: no
-    do-not-query-localhost: no
-    prefetch: yes
-    prefetch-key: yes
-    qname-minimisation: yes
-    aggressive-nsec: yes
-    ratelimit: 1000
-    rrset-roundrobin: yes
-    minimal-responses: yes
-    chroot: "/opt/unbound/etc/unbound"
+
+    # Time to live minimum for RRsets and messages in the cache. If the minimum
+    # kicks in, the data is cached for longer than the domain owner intended,
+    # and thus less queries are made to look up the data. Zero makes sure the
+    # data in the cache is as the domain owner intended, higher values,
+    # especially more than an hour or so, can lead to trouble as the data in
+    # the cache does not match up with the actual data any more.
+    cache-min-ttl: 60
+
+    # Set the working directory for the program.
     directory: "/opt/unbound/etc/unbound"
-    auto-trust-anchor-file: "var/root.key"
-    num-queries-per-thread: 4096
-    outgoing-range: 8192
-    msg-cache-size: 260991658
-    rrset-cache-size: 260991658
+
+    # RFC 6891. Number of bytes size to advertise as the EDNS reassembly buffer
+    # size. This is the value put into datagrams over UDP towards peers.
+    # 4096 is RFC recommended. 1472 has a reasonable chance to fit within a
+    # single Ethernet frame, thus lessing the chance of fragmentation
+    # reassembly problems (usually seen as timeouts). Setting to 512 bypasses
+    # even the most stringent path MTU problems, but is not recommended since
+    # the amount of TCP fallback generated is excessive.
+    edns-buffer-size: 1472
+
+    # Listen to for queries from clients and answer from this network interface
+    # and port.
+    interface: 0.0.0.0@53
+
+    # Rotates RRSet order in response (the pseudo-random number is taken from
+    # the query ID, for speed and thread safety).
+    rrset-roundrobin: yes
+
+    # Drop user  privileges after  binding the port.
+    username: "_unbound"
+
+    ###########################################################################
+    # LOGGING
+    ###########################################################################
+
+    # Do not print log lines to inform about local zone actions
+    log-local-actions: no
+
+    # Do not print one line per query to the log
+    log-queries: no
+
+    # Do not print one line per reply to the log
+    log-replies: no
+
+    # Do not print log lines that say why queries return SERVFAIL to clients
+    log-servfail: no
+
+    # Further limit logging
+    logfile: /dev/null
+
+    # Only log errors
+    verbosity: 5
+
+    ###########################################################################
+    # PRIVACY SETTINGS
+    ###########################################################################
+
+    # RFC 8198. Use the DNSSEC NSEC chain to synthesize NXDO-MAIN and other
+    # denials, using information from previous NXDO-MAINs answers. In other
+    # words, use cached NSEC records to generate negative answers within a
+    # range and positive answers from wildcards. This increases performance,
+    # decreases latency and resource utilization on both authoritative and
+    # recursive servers, and increases privacy. Also, it may help increase
+    # resilience to certain DoS attacks in some circumstances.
+    aggressive-nsec: yes
+
+    # Extra delay for timeouted UDP ports before they are closed, in msec.
+    # This prevents very delayed answer packets from the upstream (recursive)
+    # servers from bouncing against closed ports and setting off all sort of
+    # close-port counters, with eg. 1500 msec. When timeouts happen you need
+    # extra sockets, it checks the ID and remote IP of packets, and unwanted
+    # packets are added to the unwanted packet counter.
+    delay-close: 10000
+
+    # Prevent the unbound server from forking into the background as a daemon
+    do-daemonize: no
+
+    # Add localhost to the do-not-query-address list.
+    do-not-query-localhost: no
+
+    # Number  of  bytes size of the aggressive negative cache.
     neg-cache-size: 4M
-    serve-expired: yes
-    unwanted-reply-threshold: 10000
-    use-caps-for-id: yes
-    val-clean-additional: yes
-    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
+
+    # Send minimum amount of information to upstream servers to enhance
+    # privacy (best privacy).
+    qname-minimisation: yes
+
+    ###########################################################################
+    # SECURITY SETTINGS
+    ###########################################################################
+    # Only give access to recursion clients from LAN IPs
+    access-control: 127.0.0.1/32 allow
+    access-control: 192.168.0.0/16 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 10.0.0.0/8 allow
+    # access-control: fc00::/7 allow
+    # access-control: ::1/128 allow
+
+    # File with trust anchor for  one  zone, which is tracked with RFC5011
+    # probes.
+    auto-trust-anchor-file: "var/root.key"
+
+    # Enable chroot (i.e, change apparent root directory for the current
+    # running process and its children)
+    chroot: "/opt/unbound/etc/unbound"
+
+    # Deny queries of type ANY with an empty response.
+    #deny-any: yes
+
+    # Harden against algorithm downgrade when multiple algorithms are
+    # advertised in the DS record.
+    harden-algo-downgrade: yes
+
+    # RFC 8020. returns nxdomain to queries for a name below another name that
+    # is already known to be nxdomain.
+    harden-below-nxdomain: yes
+
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the
+    # zone becomes bogus. If turned off you run the risk of a downgrade attack
+    # that disables security for a zone.
+    harden-dnssec-stripped: yes
+
+    # Only trust glue if it is within the servers authority.
+    harden-glue: yes
+
+    # Ignore very large queries.
+    harden-large-queries: yes
+
+    # Perform additional queries for infrastructure data to harden the referral
+    # path. Validates the replies if trust anchors are configured and the zones
+    # are signed. This enforces DNSSEC validation on nameserver NS sets and the
+    # nameserver addresses that are encountered on the referral path to the
+    # answer. Experimental option.
+    harden-referral-path: no
+
+    # Ignore very small EDNS buffer sizes from queries.
+    harden-short-bufsize: yes
+
+    # Refuse id.server and hostname.bind queries
+    hide-identity: yes
+
+    # Refuse version.server and version.bind queries
+    hide-version: yes
+
+    # Report this identity rather than the hostname of the server.
+    identity: "DNS"
+
+    # These private network addresses are not allowed to be returned for public
+    # internet names. Any  occurrence of such addresses are removed from DNS
+    # answers. Additionally, the DNSSEC validator may mark the  answers  bogus.
+    # This  protects  against DNS  Rebinding
     private-address: 10.0.0.0/8
     private-address: 172.16.0.0/12
     private-address: 192.168.0.0/16
     private-address: 169.254.0.0/16
-    private-address: fd00::/8
-    private-address: fe80::/10
-    private-address: ::ffff:0:0/96
-    access-control: 127.0.0.1/32 allow
-    access-control: 192.168.1.1/24 allow
-    access-control: 172.16.0.0/12 allow
-    access-control: 10.0.0.0/8 allow
-    logfile: /var/log/unbound.log
-    #include: /opt/unbound/etc/unbound/a-records.conf
+    # private-address: fd00::/8
+    # private-address: fe80::/10
+    # private-address: ::ffff:0:0/96
+
+    # Enable ratelimiting of queries (per second) sent to nameserver for
+    # performing recursion. More queries are turned away with an error
+    # (servfail). This stops recursive floods (e.g., random query names), but
+    # not spoofed reflection floods. Cached responses are not rate limited by
+    # this setting. Experimental option.
+    ratelimit: 1000
+
+    # Use this certificate bundle for authenticating connections made to
+    # outside peers (e.g., auth-zone urls, DNS over TLS connections).
+    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
+
+    # Set the total number of unwanted replies to eep track of in every thread.
+    # When it reaches the threshold, a defensive action of clearing the rrset
+    # and message caches is taken, hopefully flushing away any poison.
+    # Unbound suggests a value of 10 million.
+    unwanted-reply-threshold: 10000
+
+    # Use 0x20-encoded random bits in the query to foil spoof attempts. This
+    # perturbs the lowercase and uppercase of query names sent to authority
+    # servers and checks if the reply still has the correct casing.
+    # This feature is an experimental implementation of draft dns-0x20.
+    # Experimental option.
+    use-caps-for-id: yes
+
+    # Help protect users that rely on this validator for authentication from
+    # potentially bad data in the additional section. Instruct the validator to
+    # remove data from the additional section of secure messages that are not
+    # signed properly. Messages that are insecure, bogus, indeterminate or
+    # unchecked are not affected.
+    val-clean-additional: yes
+
+    ###########################################################################
+    # PERFORMANCE SETTINGS
+    ###########################################################################
+    # https://nlnetlabs.nl/documentation/unbound/howto-optimise/
+    # https://nlnetlabs.nl/news/2019/Feb/05/unbound-1.9.0-released/
+
+    # Number of slabs in the infrastructure cache. Slabs reduce lock contention
+    # by threads. Must be set to a power of 2.
+    # infra-cache-slabs: 4
+
+    # Number of incoming TCP buffers to allocate per thread. Default
+    # is 10. If set to 0, or if do-tcp is "no", no  TCP  queries  from
+    # clients  are  accepted. For larger installations increasing this
+    # value is a good idea.
+    # incoming-num-tcp: 10
+
+    # Number of slabs in the key cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2. Setting (close) to the number
+    # of cpus is a reasonable guess.
+    # key-cache-slabs: 4
+
+    # Number  of  bytes  size  of  the  message  cache.
+    # Unbound recommendation is to Use roughly twice as much rrset cache memory
+    # as you use msg cache memory.
+    msg-cache-size: 260991658
+
+    # Number of slabs in the message cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2. Setting (close) to the number of
+    # cpus is a reasonable guess.
+    #msg-cache-slabs: 4
+
+    # The number of queries that every thread will service simultaneously. If
+    # more queries arrive that need servicing, and no queries can be jostled
+    # out (see jostle-timeout), then the queries are dropped.
+    # This is best set at half the number of the outgoing-range.
+    # This Unbound instance was compiled with libevent so it can efficiently
+    # use more than 1024 file descriptors.
+    num-queries-per-thread: 4096
+
+    # The number of threads to create to serve clients.
+    # This is set dynamically at run time to effectively use available CPUs
+    # resources
+    num-threads: 3
+
+    # Number of ports to open. This number of file descriptors can be opened
+    # per thread.
+    # This Unbound instance was compiled with libevent so it can efficiently
+    # use more than 1024 file descriptors.
+    outgoing-range: 8192
+
+    # Number of bytes size of the RRset cache.
+    # Use roughly twice as much rrset cache memory as msg cache memory
+    rrset-cache-size: 260991658
+
+    # Number of slabs in the RRset cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2.
+    #rrset-cache-slabs: 4
+
+    # Do no insert authority/additional sections into response messages when
+    # those sections are not required. This reduces response size
+    # significantly, and may avoid TCP fallback for some responses. This may
+    # cause a slight speedup.
+    minimal-responses: yes
+
+    # # Fetch the DNSKEYs earlier in the validation process, when a DS record
+    # is encountered. This lowers the latency of requests at the expense of
+    # little more CPU usage.
+    prefetch: yes
+
+    # Fetch the DNSKEYs earlier in the validation process, when a DS record is
+    # encountered. This lowers the latency of requests at the expense of little
+    # more CPU usage.
+    prefetch-key: yes
+
+    # Have unbound attempt to serve old responses from cache with a TTL of 0 in
+    # the response without waiting for the actual resolution to finish. The
+    # actual resolution answer ends up in the cache later on.
+    serve-expired: yes
+
+    # Open dedicated listening sockets for incoming queries for each thread and
+    # try to set the SO_REUSEPORT socket option on each socket. May distribute
+    # incoming queries to threads more evenly.
+    so-reuseport: yes
+
+    ###########################################################################
+    # LOCAL ZONE
+    ###########################################################################
+
+    # # Include file for local-data and local-data-ptr
+    # include: /opt/unbound/etc/unbound/a-records.conf
+    # include: /opt/unbound/etc/unbound/srv-records.conf
+
+    # ###########################################################################
+    # # FORWARD ZONE
+    # ###########################################################################
+
+    # include: /opt/unbound/etc/unbound/forward-records.conf
+    
     forward-zone:
         name: "."
         forward-addr: 1.1.1.1@853#cloudflare-dns.com
@@ -364,5 +304,7 @@ server:
         forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
         forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
         forward-tls-upstream: yes
+
     remote-control:
         control-enable: no
+

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -60,7 +60,7 @@ server:
     logfile: /dev/null
 
     # Only log errors
-    verbosity: 5
+    verbosity: 1
 
     ###########################################################################
     # PRIVACY SETTINGS
@@ -164,9 +164,9 @@ server:
     private-address: 172.16.0.0/12
     private-address: 192.168.0.0/16
     private-address: 169.254.0.0/16
-    # private-address: fd00::/8
-    # private-address: fe80::/10
-    # private-address: ::ffff:0:0/96
+    private-address: fd00::/8
+    private-address: fe80::/10
+    private-address: ::ffff:0:0/96
 
     # Enable ratelimiting of queries (per second) sent to nameserver for
     # performing recursion. More queries are turned away with an error

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -302,7 +302,7 @@
 #     control-enable: no
 
 server:
-    verbosity: 1
+    verbosity: 5
     num-threads: 3
     interface: 0.0.0.0@53
     so-reuseport: yes

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -183,14 +183,14 @@ server:
     # When it reaches the threshold, a defensive action of clearing the rrset
     # and message caches is taken, hopefully flushing away any poison.
     # Unbound suggests a value of 10 million.
-    unwanted-reply-threshold: 10000
+    unwanted-reply-threshold: 10000000
 
     # Use 0x20-encoded random bits in the query to foil spoof attempts. This
     # perturbs the lowercase and uppercase of query names sent to authority
     # servers and checks if the reply still has the correct casing.
     # This feature is an experimental implementation of draft dns-0x20.
     # Experimental option.
-    use-caps-for-id: yes
+    #use-caps-for-id: yes
 
     # Help protect users that rely on this validator for authentication from
     # potentially bad data in the additional section. Instruct the validator to
@@ -241,7 +241,7 @@ server:
     # The number of threads to create to serve clients.
     # This is set dynamically at run time to effectively use available CPUs
     # resources
-    num-threads: 3
+    #num-threads: 3
 
     # Number of ports to open. This number of file descriptors can be opened
     # per thread.
@@ -282,6 +282,9 @@ server:
     # try to set the SO_REUSEPORT socket option on each socket. May distribute
     # incoming queries to threads more evenly.
     so-reuseport: yes
+
+    # Ensure kernel buffer is large enough to not lose messages in traffic spikes
+    so-rcvbuf: 1m
 
     ###########################################################################
     # LOCAL ZONE


### PR DESCRIPTION
This PR add some more details for custom DNS provider(s) and adds some help how to choose the fastest and most reliable one (after you've chosen some that care for "independence and privacy"). One deprecated environment variable (`DNSx`) is also renamed to the new variable (`PIHOLE_DNS_x`).