### PR TITLE
Fixing warning in dnsmasq - Pi-hole diagnosis

### DIFF
--- a/etc-dnsmasq.d/99-edns.conf
+++ b/etc-dnsmasq.d/99-edns.conf
@@ -1,0 +1,1 @@
+edns-packet-max=1232


### PR DESCRIPTION
Fixing "Warning in dnsmasq core:reducing DNS packet size for nameserver 10.2.0.100 to 1232". Using unbound will result in a permanent warning in the Pi-hole diagnosis - https://docs.pi-hole.net/guides/dns/unbound/