### PR TITLE
Makes wireguard point to pihole by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       - WG_HOST=REPLACE_ME_WITH_YOUR_PUBLIC_IP
       - PASSWORD=YOUR_ADMIN_PASSWORD
+      - WG_DEFAULT_DNS=10.2.0.100
     volumes:
       - "./wireguard:/etc/wireguard"
     ports:


### PR DESCRIPTION
I spent a while for trying to understand why the PiHole was not working by default. The project description let me understand that it's virtually `docker compose up` and you are good to go.

I noticed that the `WG_DEFAULT_DNS` points to CloudFlare (1.1.1.1) by default. When changing it to `- WG_DEFAULT_DNS=10.2.0.100` and `docker compose up`, everything worked as expected.

To make the project easier to setup — especially for beginners — I'm proposing adding this default value to the `docker-compose.yml`.