### PR TITLE
Remove unnecessary sed command from quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ cd wirehole
 cp .env.example .env
 nano .env  # Or use any text editor of your choice to edit the .env file
 
-# Replace the public IP placeholder in the docker-compose.yml
-sed -i "s/REPLACE_ME_WITH_YOUR_PUBLIC_IP/$(curl -s ifconfig.me)/g" docker-compose.yml
-
 # Start the Docker containers
 docker compose up
 ```


### PR DESCRIPTION
I'm not seeing any mention of `REPLACE_ME_WITH_YOUR_PUBLIC_IP` in the docker-compose.yml, so it seems safe to remove this command from the quickstart guide:
```
# Replace the public IP placeholder in the docker-compose.yml
sed -i "s/REPLACE_ME_WITH_YOUR_PUBLIC_IP/$(curl -s ifconfig.me)/g" docker-compose.yml
```