### PR TITLE
Update .env.example WIREGUARD_PEERS -> PEERS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ WIREGUARD_PEER_DNS=10.2.0.100
 
 # Wireguard settings
 # Number of peers (clients) to generate
-WIREGUARD_PEERS=1
+PEERS=1
 
 # Wireguard-UI settings
 # Session secret, change to something secure


### PR DESCRIPTION
Fixes #111 and #113

Currently [docker-wireguard](https://github.com/linuxserver/docker-wireguard) uses the `PEERS` environment variable and not the `WIREGUARD_PEERS` that's currently in wirehole's docker-compose file. Example: [Link to docker-wireguard search for PEERS](https://github.com/search?q=repo%3Alinuxserver%2Fdocker-wireguard+%2F%28%3F-i%29PEERS%2F&type=code)

This results in [new users of wirehole not seeing any QR codes](https://github.com/IAmStoxe/wirehole/issues/113) or wireguard configs generated on their first start.

More details: https://github.com/IAmStoxe/wirehole/issues/111#issuecomment-1837201951

This PR fixes the issue by updating `WIREGUARD_PEERS` to `PEERS` to match docker-wireguard.