### PR TITLE
Remove unused and commented SUBNET from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,6 @@ PUID=1000
 PGID=1000
 
 # Network settings
-# Subnet for the private network - NOT USED IN COMPOSE FILE, CAN BE REMOVED
-# SUBNET=10.2.0.0/24
 
 # Static IP for Unbound
 UNBOUND_IPV4_ADDRESS=10.2.0.200


### PR DESCRIPTION
This PR removes these unused lines from .env.example:
```
# Subnet for the private network - NOT USED IN COMPOSE FILE, CAN BE REMOVED
# SUBNET=10.2.0.0/24
```