### PR TITLE
Remove unused WIREGUARD_PEER_DNS from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,6 @@ UNBOUND_IPV4_ADDRESS=10.2.0.200
 PIHOLE_IPV4_ADDRESS=10.2.0.100
 # Port for Wireguard server
 WIREGUARD_SERVER_PORT=51820
-# DNS for Wireguard peers, set to Pi-hole
-WIREGUARD_PEER_DNS=10.2.0.100
 
 # Wireguard settings
 # Number of peers (clients) to generate


### PR DESCRIPTION
There's no mention of `WIREGUARD_PEER_DNS` in docker-wireguard, but they do have `PEERDNS` which is currently defaulting to `auto` (results in the INTERNAL_SUBNET's gateway ip being used, but the docs say it uses the wireguard host's IP).

This PR removes the unused `WIREGUARD_PEER_DNS` so nobody thinks it's actually doing something. 